### PR TITLE
Add authentication & some QOL changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ const register = (core, args, options, metadata) => {
             h(BoxContainer, {}, 'Password'),
             h(TextField, {
               value: state.password,
+              type: 'password',
               oninput: (ev, value) => { 
                 actions.setState({key: 'password', value});
                 proc.settings.password = value;


### PR DESCRIPTION
- Added authentication as per my request #6 
- Moved Settings dialog into it's own menu option to help facilitate saving settings.
- Added rudimentary auto-login feature.

Currently the password is saved in plain-text in the client storage (whether this be on the server, or in the browser). This at least satisfies the use-case of authenticated Xpra use, if someone can provide a more secure way to store/retrieve the password, I'd be open to it.