### PR TITLE
Authentication and QOL changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,8 @@ const register = (core, args, options, metadata) => {
   let defaultOptions = {
     uri: proc.settings.uri || 'ws://localhost:10000',
     sound: proc.settings.sound || false,
-    username: proc.settings.username || "username",
-    password: proc.settings.password || "password",
+    username: proc.settings.username || 'username',
+    password: proc.settings.password || 'password',
     passwords: [ proc.settings.password ],
     autologin: proc.settings.autologin || false,
     bandwidth_limit: 0
@@ -55,7 +55,7 @@ const register = (core, args, options, metadata) => {
       cb(found);
     }
   };
-  
+
   const createConnectionDialog = (cb) => {
     const view = ($content, dialogWindow, window) => {
       window._app = app(defaultOptions, {
@@ -86,7 +86,7 @@ const register = (core, args, options, metadata) => {
             h(TextField, {
               value: state.password,
               type: 'password',
-              oninput: (ev, value) => { 
+              oninput: (ev, value) => {
                 actions.setState({key: 'password', value});
                 proc.settings.password = value;
                 proc.saveSettings();
@@ -95,7 +95,7 @@ const register = (core, args, options, metadata) => {
             h(BoxContainer, {}, 'Enable Sound (experimental) ?'),
             h(ToggleField, {
               checked: state.sound,
-              onchange: (ev, value) => { 
+              onchange: (ev, value) => {
                 actions.setState({key: 'sound', value});
                 proc.settings.sound = value;
                 proc.saveSettings();
@@ -132,7 +132,7 @@ const register = (core, args, options, metadata) => {
       .render(view);
   };
 
-  
+
   const client = createClient(defaultOptions, {
     worker: proc.resource('worker.js')
   });
@@ -153,23 +153,23 @@ const register = (core, args, options, metadata) => {
         }, {
           label: 'Settings',
           onclick: () =>
-            createConnectionDialog(options => { 
+            createConnectionDialog(options => {
               proc.settings = options;
               proc.saveSettings();
               defaultOptions = options;
             })
-        },{
+        }, {
           label: 'Windows',
           menu: []
         }]
       });
     });
-    
-    if(proc.settings.autologin == true)  {
+
+    if(proc.settings.autologin === true)  {
       defaultOptions.reconnect = true;
       client.connect(defaultOptions);
     }
-    
+
     proc.on('destroy', () => tray.destroy());
   }
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const register = (core, args, options, metadata) => {
   let status = 'disconnected';
   let windows = [];
   const proc = core.make('osjs/application', {args, options, metadata});
-  let defaultOptions = {
+  const defaultOptions = {
     uri: proc.settings.uri || 'ws://localhost:10000',
     sound: proc.settings.sound || false,
     username: proc.settings.username || 'username',
@@ -156,7 +156,7 @@ const register = (core, args, options, metadata) => {
             createConnectionDialog(options => {
               proc.settings = options;
               proc.saveSettings();
-              defaultOptions = options;
+              Object.assign(defaultOptions, options);
             })
         }, {
           label: 'Windows',

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ const register = (core, args, options, metadata) => {
             h(BoxContainer, {}, 'Password'),
             h(TextField, {
               value: state.password,
+              type: 'password',
               oninput: (ev, value) => { 
                 actions.setState({key: 'password', value});
                 proc.settings.password = value;


### PR DESCRIPTION
- Added authentication as per my request #6
- Moved Settings dialog into it's own menu option to help facilitate saving settings.
- Added rudimentary auto-login feature.

Currently the password is saved in plain-text in the client storage (whether this be on the server, or in the browser). This at least satisfies the use-case of authenticated Xpra use, if someone can provide a more secure way to store/retrieve the password, I'd be open to it.

(Recreated on request)